### PR TITLE
Improve logging in getKuzuClient with safer debug method check

### DIFF
--- a/src/services/memory.service.ts
+++ b/src/services/memory.service.ts
@@ -67,10 +67,10 @@ export class MemoryService {
     mcpContext: EnrichedRequestHandlerExtra,
     clientProjectRoot: string,
   ): Promise<KuzuDBClient> {
-    process.stdout.write(
-      `[STDOUT-DEBUG] MemoryService.getKuzuClient ENTERED with CPR: ${clientProjectRoot}\n`,
-    );
-    const logger = mcpContext.logger || console; // Fallback for safety, though context should always have logger
+    const logger = mcpContext.logger || console;
+    if (typeof (logger as any).debug === 'function') {
+      (logger as any).debug(`[MemoryService.getKuzuClient] ENTERED with CPR: ${clientProjectRoot}`);
+    }
 
     // Validate clientProjectRoot - this is critical for correct operation
     if (!clientProjectRoot) {


### PR DESCRIPTION
The logging system was reporting false positive errors due to non-JSON output on STDOUT.

*   **Root Cause**: The `MemoryService.getKuzuClient` function in `src/services/memory.service.ts` was writing a debug line directly to `process.stdout`.
    *   The MCP stdio server consumes all STDOUT, expecting JSON. This debug line caused JSON parsing failures (`Unexpected token 'S'`).
*   **Fix**:
    *   The `process.stdout.write` call was removed from `MemoryService.getKuzuClient`.
    *   It was replaced with a guarded logger call: `(logger as any).debug(...)`.
    *   This ensures debug messages are directed to STDERR (or the injected in-memory logger), preventing them from polluting STDOUT.
*   **Outcome**: Only protocol-compliant JSON now reaches STDOUT, eliminating the false "Unexpected token" errors while tool functionality remains correct.