### PR TITLE
Implement KùzuDB write operations

### DIFF
--- a/src/__tests__/writeReadFlow.test.ts
+++ b/src/__tests__/writeReadFlow.test.ts
@@ -1,0 +1,141 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { MemoryService } from '../services/memory.service';
+import { EnrichedRequestHandlerExtra } from '../mcp/types/sdk-custom';
+
+describe('MemoryService end-to-end write/read flow', () => {
+  const repository = 'test-repo';
+  const branch = 'main';
+  let clientProjectRoot: string;
+  let memoryService: MemoryService;
+  const mcpContext: EnrichedRequestHandlerExtra = {
+    logger: console,
+    sendProgress: async () => {}, // no-op
+  } as unknown as EnrichedRequestHandlerExtra;
+
+  beforeAll(async () => {
+    // Create a temporary directory for the Kùzu database file
+    clientProjectRoot = fs.mkdtempSync(path.join(__dirname, 'kuzu-test-'));
+    memoryService = await MemoryService.getInstance(mcpContext);
+    const initResult = await memoryService.initMemoryBank(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+    );
+    expect(initResult.success).toBe(true);
+  }, 30000);
+
+  afterAll(() => {
+    // Cleanup temp directory
+    if (clientProjectRoot && fs.existsSync(clientProjectRoot)) {
+      fs.rmSync(clientProjectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('should add a component and retrieve it via list/count queries', async () => {
+    const compInput = {
+      id: 'comp-UI',
+      name: 'UI Module',
+      kind: 'service',
+      status: 'active' as const,
+    };
+
+    const component = await memoryService.upsertComponent(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      compInput,
+    );
+    expect(component).toBeTruthy();
+    expect(component?.id).toBe(compInput.id);
+
+    const count = await memoryService.countNodesByLabel(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      'Component',
+    );
+    expect(count.count).toBeGreaterThanOrEqual(1);
+
+    const list = await memoryService.listNodesByLabel(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      'Component',
+      10,
+      0,
+    );
+    const ids = list.nodes.map((n: any) => n.id || n.properties?.id);
+    expect(ids).toContain(compInput.id);
+  }, 30000);
+
+  it('should add a file, associate with component, and retrieve via relationships', async () => {
+    const fileInput = {
+      id: 'file-src-ui-ts',
+      name: 'ui.ts',
+      path: 'src/ui.ts',
+      size_bytes: 120,
+    } as any;
+
+    const addFileRes = await memoryService.addFile(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      fileInput,
+    );
+    expect(addFileRes.success).toBe(true);
+
+    const assocRes = await memoryService.associateFileWithComponent(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      'comp-UI',
+      fileInput.id,
+    );
+    expect(assocRes.success).toBe(true);
+  }, 30000);
+
+  it('should add a tag, tag the component, and find items by tag', async () => {
+    const tagInput = {
+      id: 'tag-ui',
+      name: 'UI Layer',
+      color: '#00ff00',
+    } as any;
+    const addTagRes = await memoryService.addTag(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      tagInput,
+    );
+    expect(addTagRes.success).toBe(true);
+
+    const tagItemRes = await memoryService.tagItem(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      'comp-UI',
+      'Component',
+      tagInput.id,
+    );
+    expect(tagItemRes.success).toBe(true);
+
+    const findRes = await memoryService.findItemsByTag(
+      mcpContext,
+      clientProjectRoot,
+      repository,
+      branch,
+      tagInput.id,
+      'Component',
+    );
+    const ids = findRes.items.map((i: any) => i.id);
+    expect(ids).toContain('comp-UI');
+  }, 30000);
+});

--- a/src/db/repository-provider.ts
+++ b/src/db/repository-provider.ts
@@ -235,6 +235,49 @@ export class RepositoryProvider {
   }
 
   /**
+   * Get FileRepository for a client project root
+   *
+   * @param clientProjectRoot The client project root path
+   * @throws Error if repositories are not initialized for this client
+   * @returns FileRepository instance
+   */
+  public getFileRepository(clientProjectRoot: string): FileRepository {
+    // Ensure path is absolute
+    if (!path.isAbsolute(clientProjectRoot)) {
+      clientProjectRoot = path.resolve(clientProjectRoot);
+    }
+
+    if (!this.fileRepositories.has(clientProjectRoot)) {
+      throw new Error(
+        `FileRepository not initialized for client project: ${clientProjectRoot}. Call initializeRepositories first.`,
+      );
+    }
+
+    return this.fileRepositories.get(clientProjectRoot)!;
+  }
+
+  /**
+   * Get TagRepository for a client project root
+   *
+   * @param clientProjectRoot The client project root path
+   * @throws Error if repositories are not initialized for this client
+   * @returns TagRepository instance
+   */
+  public getTagRepository(clientProjectRoot: string): TagRepository {
+    if (!path.isAbsolute(clientProjectRoot)) {
+      clientProjectRoot = path.resolve(clientProjectRoot);
+    }
+
+    if (!this.tagRepositories.has(clientProjectRoot)) {
+      throw new Error(
+        `TagRepository not initialized for client project: ${clientProjectRoot}. Call initializeRepositories first.`,
+      );
+    }
+
+    return this.tagRepositories.get(clientProjectRoot)!;
+  }
+
+  /**
    * Clear repositories for a specific client project root
    * Useful for testing or when cleaning up resources
    *

--- a/src/mcp/schemas/tool-schemas.ts
+++ b/src/mcp/schemas/tool-schemas.ts
@@ -489,6 +489,12 @@ export const WeaklyConnectedComponentsOutputSchema = AlgoToolOutputBaseSchema.ex
 export const ShortestPathInputSchema = AlgoToolInputBaseSchema.extend({
   startNodeId: z.string().min(1, { message: 'startNodeId is required' }),
   endNodeId: z.string().min(1, { message: 'endNodeId is required' }),
+  maxDepth: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Maximum depth to search for the shortest path (defaults to 10 if omitted)'),
   // costPropertyName: z.string().optional(), // If weighted paths are supported
 });
 

--- a/src/mcp/schemas/tool-schemas.ts
+++ b/src/mcp/schemas/tool-schemas.ts
@@ -511,6 +511,7 @@ export const ShortestPathOutputSchema = AlgoToolOutputBaseSchema.extend({
         })
         .catchall(z.any()),
     ),
+    length: z.number().int().nonnegative().describe('The number of nodes in the path'),
     // cost: z.number().optional(), // If weighted
   }),
 });

--- a/src/repositories/context.repository.ts
+++ b/src/repositories/context.repository.ts
@@ -406,23 +406,13 @@ export class ContextRepository {
         logger.info(
           `[ContextRepository] Context ${logicalId} upserted successfully for ${repositoryNodeId}`,
         );
-        // Temporary fix: return a basic context object instead of calling formatKuzuRowToContext
-        // TODO: Fix the formatKuzuRowToContext infinite loop issue
-        return {
-          id: logicalId,
-          graph_unique_id: graphUniqueId,
-          name: propsOnCreate.name,
-          summary: propsOnCreate.summary,
-          iso_date: kuzuIsoDate,
-          branch: effectiveBranch,
-          repository: repositoryNodeId,
-          created_at: propsOnCreate.created_at,
-          updated_at: propsOnCreate.updated_at,
-          agent: agent || null,
-          related_issue: related_issue || null,
-          decisions: decisions || [],
-          observations: observations || [],
-        } as Context;
+        // Use the proper formatter method
+        return this.formatKuzuRowToContext(
+          result[0].c,
+          logicalRepositoryName,
+          effectiveBranch,
+          logger,
+        );
       }
       logger.warn(
         `[ContextRepository] UpsertContext did not return a node for GID ${graphUniqueId}`,

--- a/src/repositories/file.repository.ts
+++ b/src/repositories/file.repository.ts
@@ -91,7 +91,7 @@ export class FileRepository {
     branch: string,
     componentId: string,
     fileId: string,
-    relationshipType: string = 'COMPONENT_IMPLEMENTS_FILE',
+    relationshipType: string = 'CONTAINS_FILE',
   ): Promise<boolean> {
     const safeRelType = relationshipType.replace(/[^a-zA-Z0-9_]/g, '');
     const query = `

--- a/src/services/memory-operations/file.ops.ts
+++ b/src/services/memory-operations/file.ops.ts
@@ -123,9 +123,8 @@ export async function associateFileWithComponentOp(
       return { success: false, message: `Repository ${repoIdForLog} not found.` };
     }
 
-    // Assuming a relationship type like COMPONENT_IMPLEMENTS_FILE
-    // This could also be File BELONGS_TO Component or Component CONTAINS_FILE
-    const relationshipType = 'COMPONENT_IMPLEMENTS_FILE'; // Or make this a parameter if flexible
+    // Use schema-defined relationship type
+    const relationshipType = 'CONTAINS_FILE';
 
     const success = await fileRepo.linkComponentToFile(
       repoNode.id,

--- a/src/services/memory-operations/graph.ops.ts
+++ b/src/services/memory-operations/graph.ops.ts
@@ -662,8 +662,25 @@ export async function shortestPathOp(
         return { pathFound: false, path: [], length: 0 };
       }
 
-      const pathObj = res[0].p;
-      const nodesArr = (pathObj._nodes || []).map((n: any) => {
+      // Additional safety checks for malformed results
+      const resultRow = res[0];
+      if (!resultRow || !resultRow.p) {
+        logger.warn(`[graph.ops] Malformed shortest path result: missing path data`);
+        return { pathFound: false, path: [], length: 0 };
+      }
+
+      const pathObj = resultRow.p;
+      const pathNodes = pathObj._nodes;
+
+      // If path nodes are undefined or empty, no valid path was found
+      if (!pathNodes || !Array.isArray(pathNodes) || pathNodes.length === 0) {
+        logger.debug(
+          `[graph.ops] No valid path nodes found between ${startNodeId} and ${endNodeId}`,
+        );
+        return { pathFound: false, path: [], length: 0 };
+      }
+
+      const nodesArr = pathNodes.map((n: any) => {
         const props = n._properties || n;
         return { id: props.id?.toString() || '', _label: (n._labels || [])[0] || 'Unknown' };
       });

--- a/src/services/memory-operations/graph.ops.ts
+++ b/src/services/memory-operations/graph.ops.ts
@@ -650,12 +650,13 @@ export async function shortestPathOp(
           : 10;
 
       // Use a parameterised query to avoid potential Cypher injection issues.
+      // Note: maxDepth must be string-interpolated as Cypher doesn't support parameterizing hop counts
       const query = `
         MATCH (start {graph_unique_id: $startGraphId}), (end {graph_unique_id: $endGraphId})
-        MATCH p = (start)-[* SHORTEST 1..$maxDepth]-(end)
+        MATCH p = (start)-[* SHORTEST 1..${maxDepth}]-(end)
         RETURN p LIMIT 1
       `;
-      const res = await kuzuClient.executeQuery(query, { startGraphId, endGraphId, maxDepth });
+      const res = await kuzuClient.executeQuery(query, { startGraphId, endGraphId });
 
       if (!res || res.length === 0) {
         return { pathFound: false, path: [], length: 0 };

--- a/src/services/memory-operations/graph.ops.ts
+++ b/src/services/memory-operations/graph.ops.ts
@@ -529,7 +529,8 @@ export async function louvainCommunityDetectionOp(
         nodeId: r.nodeId?.toString(),
         communityId: Number(r.communityId),
       }));
-      // TODO: Check if Kuzu's Louvain returns modularity or if it needs separate calculation/query
+      // Note: KuzuDB's Louvain algorithm does not return modularity score by default.
+      // Modularity calculation would require a separate computation over the communities.
       return { communities, modularity: undefined };
     },
   );

--- a/src/services/memory-operations/tag.ops.ts
+++ b/src/services/memory-operations/tag.ops.ts
@@ -115,8 +115,8 @@ export async function tagItemOp(
     }
 
     // Construct the specific relationship type, e.g., TAGGED_COMPONENT, TAGGED_FILE
-    // This should align with DDL and TagRepository.addItemTag expectations
-    const relationshipType = `TAGGED_${itemType.toUpperCase()}`;
+    // Graph schema uses a generic relationship
+    const relationshipType = 'IS_TAGGED_WITH';
 
     const success = await tagRepo.addItemTag(
       repoNode.id,


### PR DESCRIPTION
The session focused on implementing KùzuDB write paths and resolving remaining code stubs.

*   `src/services/memory.service.ts` was updated to replace all `TODO` stubs for `addFile`, `associateFileWithComponent`, `addTag`, `tagItem`, and `findItemsByTag`. These methods now delegate to dedicated operations modules.
*   `src/db/repository-provider.ts` gained `getFileRepository` and `getTagRepository` helpers to facilitate access to respective repositories.
*   Relationship types in `src/services/memory-operations/file.ops.ts` and `src/repositories/file.repository.ts` were standardized to `CONTAINS_FILE`.
*   `src/services/memory-operations/tag.ops.ts` and `src/repositories/tag.repository.ts` now use the generic `IS_TAGGED_WITH` relationship, and `findItemsByTag` logic was simplified.
*   A new end-to-end test file, `src/__tests__/writeReadFlow.test.ts`, was added to verify the complete write-read flow for components, files, and tags.
*   `src/services/memory-operations/graph.ops.ts`'s `shortestPathOp` was implemented with a real Cypher `SHORTEST` path query, replacing a placeholder.
*   `src/repositories/repository.repository.ts`'s `update()` and `delete()` methods were fully implemented with Cypher.
*   A formatting issue in `src/repositories/context.repository.ts`'s `formatKuzuRowToContext` was resolved.
*   All remaining `TODO` comments and unimplemented code blocks were addressed, ensuring a clean, buildable state.