### PR TITLE
feat: update MCP SDK to v1.12.3 and move to runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:check": "eslint \"{src,apps,libs,test}/**/*.ts\" --quiet"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.3",
     "@types/node": "^22.15.17",
     "commander": "^11.1.0",
     "dotenv": "^16.5.0",
@@ -32,7 +33,6 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.4",
     "@types/jest": "^29.5.14",
     "@types/node-fetch": "^2.6.4",
     "@types/pino": "^7.0.4",


### PR DESCRIPTION
## Summary

Updates the Model Context Protocol (MCP) SDK to the latest version to resolve compatibility issues with Augment IDE.

## Changes

- **Update MCP SDK**: `@modelcontextprotocol/sdk` from `^1.11.4` to `^1.12.3`
- **Fix dependency classification**: Move MCP SDK from `devDependencies` to `dependencies` (it's required at runtime)
- **Compatibility improvement**: Latest SDK version should resolve timeout issues when starting MCP server in Augment IDE

## Problem Solved

Augment IDE was experiencing MCP server startup timeouts with error:
```
MCP error -2: Request timed out
```

While other IDEs (Cursor, Roocode, Windsurf) worked fine, suggesting Augment has stricter MCP protocol compliance requirements.

## Testing

- ✅ Build completes successfully with new SDK version
- ✅ HTTP stream server starts and shuts down properly
- ✅ All 10 MCP tools register correctly
- ✅ No breaking changes or compatibility issues detected

## Technical Details

The MCP SDK was incorrectly placed in `devDependencies` but is actually required at runtime for the MCP server functionality. The latest version (1.12.3) includes improvements that should resolve the protocol compatibility issues with Augment's MCP implementation.

**Before:**
```json
"devDependencies": {
  "@modelcontextprotocol/sdk": "^1.11.4"
}
```

**After:**
```json
"dependencies": {
  "@modelcontextprotocol/sdk": "^1.12.3"
}
```

## Next Steps

After merging, test the MCP server startup in Augment IDE to verify the timeout issue is resolved.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded "@modelcontextprotocol/sdk" to a newer version and moved it to runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->